### PR TITLE
Add build method overrides for benchmarks.

### DIFF
--- a/hsbencher/HSBencher/Types.hs
+++ b/hsbencher/HSBencher/Types.hs
@@ -254,7 +254,8 @@ data Benchmark a = Benchmark
  , configs :: BenchSpace a  -- ^ The configration space to iterate over.
  , progname :: Maybe String -- ^ Optional name to use to identify this benchmark, INSTEAD of the basename from `target`.
  , benchTimeOut :: Maybe Double -- ^ Specific timeout for this benchmark in seconds.  Overrides global setting.
- } deriving (Eq, Show, Ord, Generic)
+ , overrideMethod :: Maybe BuildMethod -- ^ Force use of this specific build method.
+ } deriving (Show, Generic)
 
 -- TODO: We could allow arbitrary shell scripts in lieu of the "target" file:
 -- data BenchTarget
@@ -266,7 +267,7 @@ data Benchmark a = Benchmark
 -- defaults to fill in the rest.  Takes target, cmdargs, configs.
 mkBenchmark :: FilePath -> [String] -> BenchSpace a -> Benchmark a 
 mkBenchmark  target  cmdargs configs = 
-  Benchmark {target, cmdargs, configs, progname=Nothing, benchTimeOut=Nothing }
+  Benchmark {target, cmdargs, configs, progname=Nothing, benchTimeOut=Nothing, overrideMethod=Nothing }
 
 
 -- | A datatype for describing (generating) benchmark configuration spaces.
@@ -448,6 +449,9 @@ data SubProcess =
 instance Out ParamSetting
 instance Out FilePredicate
 instance Out DefaultParamMeaning
+instance Out BuildMethod where
+  docPrec n m = docPrec n $ methodName m
+  doc         = docPrec 0
 instance Out a => Out (BenchSpace a)
 instance Out a => Out (Benchmark a)
 


### PR DESCRIPTION
As mentioned in #49, had to remove `Eq` and `Ord` instances for `BuildMethod`. This is fine as they weren't used anywhere. I also added a simple `Out` instance for `BuildMethod`. @rrnewton, how's this look?
