### PR TITLE
Added a set of harvesters which accumulate their data over trials.

### DIFF
--- a/hsbencher/HSBencher/Harvesters.hs
+++ b/hsbencher/HSBencher/Harvesters.hs
@@ -1,7 +1,12 @@
 
 module HSBencher.Harvesters ( customTagHarvesterInt,
                               customTagHarvesterDouble,
-                              customTagHarvesterString) where
+                              customTagHarvesterString,
+
+                              customAccumHarvesterInt,
+                              customAccumHarvesterDouble,
+                              customAccumHarvesterString
+                              ) where
 
 import HSBencher.Types
 import HSBencher.Internal.MeasureProcess 
@@ -28,7 +33,22 @@ customTagHarvesterString tag =
   taggedLineHarvesterStr (pack tag) $
     \s r -> r {custom = (tag,StringResult s) : custom r}
 
+-- Harvesters which accumulate their output over multiple "trials"
+customAccumHarvesterInt :: String -> LineHarvester
+customAccumHarvesterInt    = accumHarvester IntResult
 
+customAccumHarvesterDouble :: String -> LineHarvester
+customAccumHarvesterDouble = accumHarvester DoubleResult
+
+customAccumHarvesterString :: String -> LineHarvester
+customAccumHarvesterString = accumHarvester StringResult
+
+accumHarvester :: Read a => (a -> SomeResult) -> String -> LineHarvester
+accumHarvester ctr tag =
+  taggedLineHarvester (pack tag) $ \s r ->
+            r {
+                custom = (tag, AccumResult [ctr s]) : custom r
+              }
 
 ---------------------------------------------------------------------------
 -- Internal.

--- a/hsbencher/HSBencher/Types.hs
+++ b/hsbencher/HSBencher/Types.hs
@@ -557,14 +557,16 @@ instance Show LineHarvester where
 ----------------------------------------------------------------------------------------------------
 type Tag = String
 data SomeResult = IntResult Int
-                | DoubleResult Double 
+                | DoubleResult Double
                 | StringResult String
+                | AccumResult [SomeResult]
                   -- expand here 
                 deriving (Eq, Read, Ord)
 instance Show SomeResult where
-  show (IntResult i) = show i
-  show (DoubleResult d) = show d
-  show (StringResult str) = str 
+  show (IntResult i)        = show i
+  show (DoubleResult d)     = show d
+  show (StringResult str)   = str
+  show (AccumResult resLst) = unwords (map show resLst)
 
 -- | This contains all the contextual information for a single benchmark run, which
 --   makes up a "row" in a table of benchmark results.


### PR DESCRIPTION
The output is similar to the runtime output (space separated values within a
column).

The user can choose to use an accumulated harvester or a single value harvester
allowing flexibility.

A similar datatype based model could be used to extend this in future (i.e to take median values etc).