### PR TITLE
Export orphan Functor instances from base-orphans

### DIFF
--- a/hsbencher/hsbencher.cabal
+++ b/hsbencher/hsbencher.cabal
@@ -207,7 +207,7 @@ Library
                    HSBencher.Internal.MeasureProcess
   other-modules: Paths_hsbencher
   build-depends:
-      base >= 4.5 && < 4.9, bytestring, process >= 1.2,
+      base >= 4.5 && < 4.9, base-orphans, bytestring, process >= 1.2,
       directory, filepath, random, unix, containers, time, mtl,
       async >= 2.0,
       io-streams >= 1.1,

--- a/hsbencher/src/HSBencher/Types.hs
+++ b/hsbencher/src/HSBencher/Types.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | All the core types used by the rest of the HSBencher codebase.
@@ -70,6 +69,7 @@ import Data.Word
 import Data.List
 import Data.Monoid
 import Data.Maybe (fromMaybe)
+import Data.Orphans ()
 import Data.Dynamic
 import Data.Default (Default(..))
 import qualified Data.Map as M
@@ -906,22 +906,6 @@ tupleToResult tuple = BenchmarkResult
 
 --------------------------------------------------------------------------------
 -- Generic uploader interface
---------------------------------------------------------------------------------
-
--- Only for GHC 7.6 and earlier:
-#if !MIN_VERSION_base(4,7,0)
-instance Functor OptDescr where
-  fmap fn (Option shrt long args str) =
-    Option shrt long (fmap fn args) str
-
-instance Functor ArgDescr where
-  fmap fn x =
-    case x of
-      NoArg x ->  NoArg (fn x)
-      ReqArg fn2 str -> ReqArg (fn . fn2) str
-      OptArg fn2 str -> OptArg (fn . fn2) str
-#endif
-
 --------------------------------------------------------------------------------
 
 -- | An interface for plugins provided in separate packages.  These plugins provide


### PR DESCRIPTION
Currently, `hsbencher` defines orphan `Functor` instances for `OptDescr` and `ArgDescr`. However, there is at least one other package that exports these same orphan instances ([`test-framework`](https://github.com/haskell/test-framework/blob/master/core/Test/Framework/Runners/Console.hs#L28-36)), possibly others. If these packages were used together on an old version of GHC, it could lead to instance conflicts.

To help mitigate this possibility, this pull request imports these instances from the `base-orphans` library (which exports backported instances introduced in later versions of `base`, including the aforementioned ones). This way, we can keep all of these orphan instances in one package so that `hsbencher`, `test-framework`, etc. can coexist.